### PR TITLE
Add requirements to setup.py to succeed with pipx install glpic

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+prettytable
+python-dateutil
+requests

--- a/setup.py
+++ b/setup.py
@@ -1,29 +1,32 @@
 # coding=utf-8
-from setuptools import setup, find_packages
-
 import os
-INSTALL = ['requests']
 
-description = 'Glpic wrapper'
+from setuptools import find_packages, setup
+
+description = "Glpic wrapper"
 long_description = description
-if os.path.exists('README.rst'):
-    long_description = open('README.rst').read()
+if os.path.exists("README.rst"):
+    long_description = open("README.rst").read()
+
+with open("requirements.txt") as f:
+    requirements = f.read().splitlines()
 
 setup(
-    name='glpic',
-    version='99.0',
+    name="glpic",
+    python_requires=">3",
+    install_requires=requirements,
+    version="99.0",
     include_package_data=True,
     packages=find_packages(),
     zip_safe=False,
     description=description,
     long_description=long_description,
-    url='http://github.com/karmab/glpic',
-    author='Karim Boumedhel',
-    author_email='karimboumedhel@gmail.com',
-    license='ASL',
-    install_requires=['prettytable'],
-    entry_points='''
+    url="http://github.com/karmab/glpic",
+    author="Karim Boumedhel",
+    author_email="karimboumedhel@gmail.com",
+    license="ASL",
+    entry_points="""
         [console_scripts]
         glpic=glpic.cli:cli
-    ''',
+    """,
 )


### PR DESCRIPTION
Pipx was failing because of python version used and no dateutil installed, instruct setup.py to define them via requirements.txt so that it's installed by default